### PR TITLE
Add instructions for building executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+uploads/
+results/
+*.zip
+dist/
+build/
+bin/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # PyMIDImaker
+
+PyMIDImaker es una pequeña aplicación web escrita en Python que permite:
+
+* Separar archivos MP3 o WAV en "stems" utilizando [Spleeter](https://github.com/deezer/spleeter).
+* Convertir cada stem en un archivo MIDI utilizando `librosa` y `pretty_midi`.
+
+El usuario sube un archivo de audio desde la página principal y al terminar el proceso descarga un ZIP con los stems en formato WAV y sus correspondientes archivos MIDI.
+
+## Instalación
+
+1. Crear y activar un entorno virtual de Python.
+2. Instalar las dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+**Nota**: `spleeter` y `librosa` son librerías pesadas y pueden requerir bibliotecas de audio adicionales.
+
+## Uso
+
+```bash
+python app.py
+```
+
+Abrir `http://localhost:5000` en el navegador, seleccionar el archivo MP3/WAV y esperar a que aparezca el enlace de descarga.
+
+Los resultados se guardan en la carpeta `results/`.
+
+## Crear un ejecutable (Windows)
+
+Para generar un `.exe` se puede utilizar [PyInstaller](https://pyinstaller.org/):
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile app.py
+```
+
+El ejecutable se ubicará en la carpeta `dist/`.
+
+## Generar un APK
+
+Para compilar la aplicación para Android se recomienda usar
+[Buildozer](https://github.com/kivy/buildozer). Se debe instalar en un entorno
+Linux y ejecutar:
+
+```bash
+pip install buildozer
+buildozer init  # crea buildozer.spec
+# editar buildozer.spec según sea necesario
+buildozer -v android debug
+```
+
+El archivo APK quedará en la carpeta `bin/`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,86 @@
+import os
+import uuid
+import zipfile
+from pathlib import Path
+
+from flask import Flask, render_template, request, send_from_directory, redirect, url_for
+
+from spleeter.separator import Separator
+import librosa
+import pretty_midi
+
+UPLOAD_FOLDER = 'uploads'
+RESULTS_FOLDER = 'results'
+
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+os.makedirs(RESULTS_FOLDER, exist_ok=True)
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files.get('file')
+    if not file:
+        return redirect(url_for('index'))
+    file_id = str(uuid.uuid4())
+    audio_path = os.path.join(UPLOAD_FOLDER, f"{file_id}_{file.filename}")
+    file.save(audio_path)
+    result_dir = os.path.join(RESULTS_FOLDER, file_id)
+    os.makedirs(result_dir, exist_ok=True)
+    separate_and_convert(audio_path, result_dir)
+    zip_path = os.path.join(RESULTS_FOLDER, f"{file_id}.zip")
+    with zipfile.ZipFile(zip_path, 'w') as zf:
+        for root, _, files in os.walk(result_dir):
+            for fname in files:
+                full = os.path.join(root, fname)
+                zf.write(full, arcname=fname)
+    return render_template('download.html', zip_file=f"{file_id}.zip")
+
+@app.route('/download/<path:filename>')
+def download(filename):
+    return send_from_directory(RESULTS_FOLDER, filename, as_attachment=True)
+
+def separate_and_convert(audio_path: str, output_dir: str):
+    separator = Separator('spleeter:2stems')
+    separator.separate_to_file(audio_path, output_dir)
+    stems_subdir = os.path.join(output_dir, Path(audio_path).stem)
+    for fname in os.listdir(stems_subdir):
+        if fname.endswith('.wav'):
+            wav_path = os.path.join(stems_subdir, fname)
+            midi_path = os.path.join(stems_subdir, Path(fname).stem + '.mid')
+            audio_to_midi(wav_path, midi_path)
+
+def audio_to_midi(wav_path: str, midi_path: str, sr: int = 22050):
+    y, sr = librosa.load(wav_path, sr=sr)
+    f0, voiced_flag, _ = librosa.pyin(y, fmin=librosa.note_to_hz('C2'), fmax=librosa.note_to_hz('C7'))
+    times = librosa.times_like(f0, sr=sr)
+    midi = pretty_midi.PrettyMIDI()
+    instrument = pretty_midi.Instrument(program=0)
+    note_start = None
+    note_pitch = None
+    for t, freq, voiced in zip(times, f0, voiced_flag):
+        if voiced:
+            pitch = int(librosa.hz_to_midi(freq))
+            if note_start is None:
+                note_start = t
+                note_pitch = pitch
+            elif pitch != note_pitch:
+                instrument.notes.append(pretty_midi.Note(velocity=100, pitch=note_pitch, start=note_start, end=t))
+                note_start = t
+                note_pitch = pitch
+        else:
+            if note_start is not None:
+                instrument.notes.append(pretty_midi.Note(velocity=100, pitch=note_pitch, start=note_start, end=t))
+                note_start = None
+                note_pitch = None
+    if note_start is not None:
+        instrument.notes.append(pretty_midi.Note(velocity=100, pitch=note_pitch, start=note_start, end=times[-1]))
+    midi.instruments.append(instrument)
+    midi.write(midi_path)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+spleeter
+librosa
+pretty_midi
+soundfile

--- a/templates/download.html
+++ b/templates/download.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PyMIDImaker</title>
+</head>
+<body>
+  <h1>¡Procesamiento finalizado!</h1>
+  <p><a href="{{ url_for('download', filename=zip_file) }}">Descargar resultados</a></p>
+  <p><a href="{{ url_for('index') }}">Procesar otro archivo</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PyMIDImaker</title>
+</head>
+<body>
+  <h1>Procesar archivo de audio</h1>
+  <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data">
+    <input type="file" name="file" accept=".mp3,.wav" required>
+    <button type="submit">Subir y procesar</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document how to build a Windows EXE with PyInstaller
- document how to generate an Android APK with Buildozer
- ignore typical build output directories

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884394860888330b7fc4513b8752f7a